### PR TITLE
Add VAD and midrange enhancement

### DIFF
--- a/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/enhance_soft_voices_full - Copy/enhance_soft_voices_full.py
+++ b/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/enhance_soft_voices_full - Copy/enhance_soft_voices_full.py
@@ -1,11 +1,51 @@
 import os
 import sys
 import subprocess
+import hashlib
 import librosa
 import soundfile as sf
 import numpy as np
+import scipy.signal as signal
+import webrtcvad
 
-print("🔊 Full Soft Voice Enhancer + Transcriber")
+
+def bandpass_filter(data, sr, low=300, high=3400):
+    """Apply a band-pass filter to `data`."""
+    sos = signal.butter(4, [low, high], btype="band", fs=sr, output="sos")
+    return signal.sosfilt(sos, data)
+
+
+def detect_voice_segments(y, sr, aggressiveness=3):
+    """Return voice segments ``(start, end)`` detected via WebRTC VAD."""
+    vad = webrtcvad.Vad(aggressiveness)
+    mono = librosa.to_mono(y) if y.ndim > 1 else y
+    resampled = librosa.resample(mono, orig_sr=sr, target_sr=16000)
+    max_abs = np.max(np.abs(resampled)) or 1.0
+    int16 = (resampled / max_abs * 32767).astype(np.int16)
+    frame_length = int(16000 * 0.03)
+    segments, start = [], None
+    for i in range(0, len(int16), frame_length):
+        frame = int16[i : i + frame_length]
+        if len(frame) < frame_length:
+            break
+        speech = vad.is_speech(frame.tobytes(), 16000)
+        t = i / 16000.0
+        if speech and start is None:
+            start = t
+        elif not speech and start is not None:
+            segments.append((start, t))
+            start = None
+    if start is not None:
+        segments.append((start, len(int16) / 16000.0))
+    return segments
+
+
+def fingerprint_segment(segment, sr):
+    """Return a simple fingerprint hash for a voice ``segment``."""
+    mfcc = librosa.feature.mfcc(y=segment, sr=sr, n_mfcc=13)
+    return hashlib.md5(mfcc.mean(axis=1).astype(np.float32).tobytes()).hexdigest()
+
+print("🔊 Full Soft Voice Enhancer + Transcriber (VAD + Fingerprint)")
 
 input_path = input("Enter full path to your audio/video file (.wav, .mp3, .mp4): ").strip().strip('"')
 if not os.path.exists(input_path):
@@ -17,23 +57,48 @@ ext = os.path.splitext(input_path)[1].lower()
 
 try:
     print("📥 Loading audio...")
-    y, sr = librosa.load(input_path, sr=None)
+    y, sr = sf.read(input_path, always_2d=False, dtype="float32")
 except Exception as e:
     print(f"❌ Error loading file: {e}")
     sys.exit(1)
 
+# Resample to 192kHz if needed
+if sr != 192000:
+    y = librosa.resample(y, orig_sr=sr, target_sr=192000)
+    sr = 192000
+
+# Detect voice segments using VAD
+segments = detect_voice_segments(y, sr)
+if segments:
+    print(f"🗣️ Detected {len(segments)} voice segments")
+else:
+    print("ℹ️ No speech detected - continuing with full audio")
+
 try:
     print("🎚️ Enhancing soft voices...")
+
+    # Mid-range boost for detected voice segments
+    y_proc = np.array(y, dtype=np.float32)
+    for start, end in segments:
+        s = int(start * sr)
+        e = int(end * sr)
+        seg = y_proc[s:e]
+        if len(seg) == 0:
+            continue
+        fp = fingerprint_segment(seg, sr)
+        print(f"   🔑 fingerprint {fp[:8]} from {start:.2f}s to {end:.2f}s")
+        y_proc[s:e] = bandpass_filter(seg, sr, 500, 5000)
+
     frame_length = 2048
     hop_length = 512
-    rms = librosa.feature.rms(y=y, frame_length=frame_length, hop_length=hop_length)[0]
+    rms = librosa.feature.rms(y=y_proc, frame_length=frame_length, hop_length=hop_length)[0]
     rms_db = librosa.amplitude_to_db(rms, ref=np.max)
     gain_mask = np.where(rms_db < -30, 10**(((-30 - rms_db) / 20)), 1.0)
     gain_expanded = np.repeat(gain_mask, hop_length)
-    gain_expanded = gain_expanded[:len(y)] if len(gain_expanded) > len(y) else np.pad(gain_expanded, (0, len(y) - len(gain_expanded)))
-    y_enhanced = np.clip(y * gain_expanded, -1.0, 1.0)
+    gain_expanded = gain_expanded[:len(y_proc)] if len(gain_expanded) > len(y_proc) else np.pad(gain_expanded, (0, len(y_proc) - len(gain_expanded)))
+    y_enhanced = np.clip(y_proc * gain_expanded, -1.0, 1.0)
     wav_output = f"enhanced_{base_name}.wav"
-    sf.write(wav_output, y_enhanced, sr)
+    sf.write(wav_output, y_enhanced, sr, subtype="PCM_32")
     print(f"✅ Saved enhanced audio: {wav_output}")
 except Exception as e:
     print(f"❌ Enhancement error: {e}")


### PR DESCRIPTION
## Summary
- handle 32‑bit 192 kHz audio in **enhance_soft_voices_full.py**
- detect voice with WebRTC VAD and apply mid‑range band‑pass filter
- output 32‑bit PCM, compute simple fingerprints for segments

## Testing
- `python -m py_compile 'Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/enhance_soft_voices_full - Copy/enhance_soft_voices_full.py'`
- `python 'Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/enhance_soft_voices_full - Copy/enhance_soft_voices_full.py' <<EOF
./test.wav
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6883b39519f48320a3efbd0f0dd04caa