### PR TITLE
Enable 192kHz 32‑bit pipeline in LiveVoiceAutoZoom

### DIFF
--- a/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/gui.py
+++ b/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/gui.py
@@ -7,7 +7,7 @@ import time
 import sounddevice as sd
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-from recorder import record_audio, save_audio, find_zoom_input
+from recorder import record_audio, save_audio, find_zoom_input, SAMPLE_RATE
 from vad_enhancer import detect_voiced, enhance_audio
 from speaker_recognition import extract_embedding, load_known_speakers, recognize_speaker
 
@@ -61,14 +61,14 @@ class VoiceRecorderGUI:
             self.canvas.draw()
 
         with sd.InputStream(device=self.device_index, channels=1,
-                            samplerate=44100, dtype='float32', callback=callback):
+                            samplerate=SAMPLE_RATE, dtype='int32', callback=callback):
             while self.recording:
                 time.sleep(0.1)
 
-        audio_np = np.array(buffer, dtype=np.float32)
+        audio_np = np.array(buffer, dtype=np.int32)
         save_audio("scripts/temp_raw.wav", audio_np)
 
-        voiced = detect_voiced(audio_np)
+        voiced = detect_voiced(audio_np, sample_rate=SAMPLE_RATE)
         enhanced = enhance_audio(voiced)
         save_audio("scripts/temp_enhanced.wav", enhanced)
 

--- a/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/recorder.py
+++ b/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/recorder.py
@@ -3,9 +3,9 @@ import sounddevice as sd
 import soundfile as sf
 import numpy as np
 
-SAMPLE_RATE = 44100
+SAMPLE_RATE = 192000
 CHANNELS = 1
-BIT_DEPTH = 'FLOAT'
+BIT_DEPTH = 'PCM_32'
 
 def find_zoom_input():
     for idx, d in enumerate(sd.query_devices()):
@@ -19,10 +19,10 @@ def record_audio(duration_sec=10, device_index=None):
         device_index = find_zoom_input()
 
     audio = sd.rec(int(duration_sec * SAMPLE_RATE), samplerate=SAMPLE_RATE,
-                   channels=CHANNELS, dtype='float32', device=device_index)
+                   channels=CHANNELS, dtype='int32', device=device_index)
     sd.wait()
     return audio
 
 def save_audio(filename, audio_data):
-    sf.write(filename, audio_data.astype('float32'), SAMPLE_RATE, subtype=BIT_DEPTH)
+    sf.write(filename, audio_data.astype('int32'), SAMPLE_RATE, subtype=BIT_DEPTH)
     print(f"[Saved] Audio to {filename}")

--- a/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/scripts/gui.py
+++ b/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/scripts/gui.py
@@ -7,7 +7,7 @@ import time
 import sounddevice as sd
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-from recorder import record_audio, save_audio, find_zoom_input
+from recorder import record_audio, save_audio, find_zoom_input, SAMPLE_RATE
 from vad_enhancer import detect_voiced, enhance_audio
 from speaker_recognition import extract_embedding, load_known_speakers, recognize_speaker
 
@@ -61,14 +61,14 @@ class VoiceRecorderGUI:
             self.canvas.draw()
 
         with sd.InputStream(device=self.device_index, channels=1,
-                            samplerate=44100, dtype='float32', callback=callback):
+                            samplerate=SAMPLE_RATE, dtype='int32', callback=callback):
             while self.recording:
                 time.sleep(0.1)
 
-        audio_np = np.array(buffer, dtype=np.float32)
+        audio_np = np.array(buffer, dtype=np.int32)
         save_audio("scripts/temp_raw.wav", audio_np)
 
-        voiced = detect_voiced(audio_np)
+        voiced = detect_voiced(audio_np, sample_rate=SAMPLE_RATE)
         enhanced = enhance_audio(voiced)
         save_audio("scripts/temp_enhanced.wav", enhanced)
 

--- a/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/scripts/recorder.py
+++ b/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/scripts/recorder.py
@@ -3,9 +3,9 @@ import sounddevice as sd
 import soundfile as sf
 import numpy as np
 
-SAMPLE_RATE = 44100
+SAMPLE_RATE = 192000
 CHANNELS = 1
-BIT_DEPTH = 'FLOAT'
+BIT_DEPTH = 'PCM_32'
 
 def find_zoom_input():
     for idx, d in enumerate(sd.query_devices()):
@@ -19,10 +19,10 @@ def record_audio(duration_sec=10, device_index=None):
         device_index = find_zoom_input()
 
     audio = sd.rec(int(duration_sec * SAMPLE_RATE), samplerate=SAMPLE_RATE,
-                   channels=CHANNELS, dtype='float32', device=device_index)
+                   channels=CHANNELS, dtype='int32', device=device_index)
     sd.wait()
     return audio
 
 def save_audio(filename, audio_data):
-    sf.write(filename, audio_data.astype('float32'), SAMPLE_RATE, subtype=BIT_DEPTH)
+    sf.write(filename, audio_data.astype('int32'), SAMPLE_RATE, subtype=BIT_DEPTH)
     print(f"[Saved] Audio to {filename}")

--- a/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/scripts/vad_enhancer.py
+++ b/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/scripts/vad_enhancer.py
@@ -2,8 +2,9 @@
 import numpy as np
 import webrtcvad
 import collections
+import librosa
 
-SAMPLE_RATE = 44100
+SAMPLE_RATE = 192000
 FRAME_DURATION = 30  # ms
 VAD_MODE = 2  # 0-3: higher = more aggressive
 
@@ -15,6 +16,9 @@ def frame_generator(audio, sample_rate, frame_duration_ms):
         yield audio[i:i + frame_len]
 
 def detect_voiced(audio, sample_rate=SAMPLE_RATE):
+    if sample_rate not in (8000, 16000, 32000, 48000):
+        audio = librosa.resample(audio.astype(np.float32), orig_sr=sample_rate, target_sr=48000)
+        sample_rate = 48000
     if audio.dtype != np.int16:
         audio = (audio * 32767).astype(np.int16)
     frames = frame_generator(audio, sample_rate, FRAME_DURATION)
@@ -29,6 +33,14 @@ def enhance_audio(voiced_audio):
         return np.zeros(1, dtype=np.float32)
     if voiced_audio.dtype != np.float32:
         voiced_audio = voiced_audio.astype(np.float32) / 32767
-    normalized = voiced_audio / np.max(np.abs(voiced_audio))
+    from scipy.signal import butter, lfilter
+
+    def bandpass(data, low, high, fs, order=4):
+        nyq = 0.5 * fs
+        b, a = butter(order, [low / nyq, high / nyq], btype="band")
+        return lfilter(b, a, data)
+
+    filtered = bandpass(voiced_audio, 300, 6000, SAMPLE_RATE)
+    normalized = filtered / (np.max(np.abs(filtered)) or 1)
     amplified = normalized * 0.9
     return amplified.astype(np.float32)

--- a/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/vad_enhancer.py
+++ b/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/vad_enhancer.py
@@ -2,8 +2,9 @@
 import numpy as np
 import webrtcvad
 import collections
+import librosa
 
-SAMPLE_RATE = 44100
+SAMPLE_RATE = 192000
 FRAME_DURATION = 30  # ms
 VAD_MODE = 2  # 0-3: higher = more aggressive
 
@@ -15,6 +16,9 @@ def frame_generator(audio, sample_rate, frame_duration_ms):
         yield audio[i:i + frame_len]
 
 def detect_voiced(audio, sample_rate=SAMPLE_RATE):
+    if sample_rate not in (8000, 16000, 32000, 48000):
+        audio = librosa.resample(audio.astype(np.float32), orig_sr=sample_rate, target_sr=48000)
+        sample_rate = 48000
     if audio.dtype != np.int16:
         audio = (audio * 32767).astype(np.int16)
     frames = frame_generator(audio, sample_rate, FRAME_DURATION)
@@ -29,6 +33,14 @@ def enhance_audio(voiced_audio):
         return np.zeros(1, dtype=np.float32)
     if voiced_audio.dtype != np.float32:
         voiced_audio = voiced_audio.astype(np.float32) / 32767
-    normalized = voiced_audio / np.max(np.abs(voiced_audio))
+    from scipy.signal import butter, lfilter
+
+    def bandpass(data, low, high, fs, order=4):
+        nyq = 0.5 * fs
+        b, a = butter(order, [low / nyq, high / nyq], btype="band")
+        return lfilter(b, a, data)
+
+    filtered = bandpass(voiced_audio, 300, 6000, SAMPLE_RATE)
+    normalized = filtered / (np.max(np.abs(filtered)) or 1)
     amplified = normalized * 0.9
     return amplified.astype(np.float32)


### PR DESCRIPTION
## Summary
- record at 192000 Hz using 32‑bit PCM
- apply VAD and mid‑range bandpass filter before fingerprinting
- update GUI and helper scripts for new audio format

## Testing
- `python -m py_compile Mute-Voce-2.0-main\ (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/live_zoom_record_and_analyze.py`
- `python -m py_compile Mute-Voce-2.0-main\ (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/recorder.py Mute-Voce-2.0-main\ (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/vad_enhancer.py Mute-Voce-2.0-main\ (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/gui.py Mute-Voce-2.0-main\ (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/scripts/recorder.py Mute-Voce-2.0-main\ (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/scripts/vad_enhancer.py Mute-Voce-2.0-main\ (1)/Mute-Voce-2.0-main/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/scripts/gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6883fd5d31d083208fbe0a30312d8c42