### PR TITLE
Add minimal pytest suite

### DIFF
--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from pydub.generators import Sine
+from enhance_audio_files.enhance_audio import detect_voice_segments
+
+
+def test_detect_voice_segments_returns_list():
+    seg = Sine(440).to_audio_segment(duration=1000).set_frame_rate(16000)
+    segments = detect_voice_segments(seg, frame_duration_ms=30, aggressiveness=3)
+    assert isinstance(segments, list)
+    for start, end in segments:
+        assert 0 <= start < end <= seg.duration_seconds

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import numpy as np
+from enhance_audio_files.enhance_audio import (
+    apply_low_pass_filter,
+    apply_high_pass_filter,
+    apply_band_pass_filter,
+)
+
+
+def test_low_pass_constant():
+    data = np.ones(10000)
+    out = apply_low_pass_filter(data, 16000, 1000)
+    assert out.shape == data.shape
+    # final samples should remain near the original value
+    assert np.allclose(out[-100:], 1, atol=1e-3)
+
+
+def test_high_pass_constant():
+    data = np.ones(10000)
+    out = apply_high_pass_filter(data, 16000, 1000)
+    assert out.shape == data.shape
+    # constant component should be largely removed
+    assert np.allclose(out[-100:], 0, atol=1e-3)
+
+
+def test_band_pass_constant():
+    data = np.ones(10000)
+    out = apply_band_pass_filter(data, 16000, 500, 5000)
+    assert out.shape == data.shape
+    # band-pass should also remove the DC component
+    assert np.allclose(out[-100:], 0, atol=1e-3)


### PR DESCRIPTION
## Summary
- add `tests/` directory with unit tests for helper functions
- verify filters keep the correct shape and expected behavior
- check voice segment detection runs on a generated tone

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68847f96e8548320a1b3f1c6cddae0c2