### PR TITLE
Fix README instructions

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,12 +2,8 @@ This project provides a Python script to enhance audio files and optionally anal
 
 Usage on Windows:
 1. Install Python 3 and ensure `python` is on your PATH.
- n7paiv-codex/analyze-script-for-ai-voice-analysis-integration
 2. Run `pip install -r requirements.txt` to install required libraries.
-3. Double-click `enhance_audio.bat` or run it from the command prompt.
-
- Double-click `enhance_audio.bat` or run it from the command prompt.
- main
+3. Double-click `enhance_audio.bat` or run it from the command prompt. When prompted:
    - Provide the full path to the input audio file **without quotes**.
    - Provide either a full output file path **or a directory** where the enhanced file will be saved. Quotes are optional.
    - Choose the low-frequency enhancement value (e.g. 875).


### PR DESCRIPTION
## Summary
- clean leftover `n7paiv-codex` reference
- remove the duplicate main block and keep a single instruction flow from installing Python to running `enhance_audio.bat`

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0 echo | head -n 1)` (fails due to quoting)
- `python -m py_compile $(git ls-files '*.py' | head -n 1)` (fails due to quoting)

------
https://chatgpt.com/codex/tasks/task_e_68847f927a288320967b3db8b5ece8b8