### PR TITLE
Add m4a support to LFN batch analyzer

### DIFF
--- a/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LFN_Docker_Toolkit_Extended/LFN_Docker_Toolkit_Extended/README.txt
+++ b/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LFN_Docker_Toolkit_Extended/LFN_Docker_Toolkit_Extended/README.txt
@@ -1,0 +1,28 @@
+LFN Docker Toolkit Extended
+==========================
+
+This directory contains helper scripts for analyzing audio files for low-frequency noise (LFN) and ultrasonic peaks.
+
+Setup
+-----
+1. Install [Python 3](https://www.python.org/downloads/).
+2. Install the required Python libraries:
+
+```
+pip install -r requirements.txt
+```
+
+3. Ensure [`ffmpeg`](https://ffmpeg.org/) is installed and available on your PATH. It is used to convert non‑WAV files to WAV.
+
+Usage
+-----
+You can run the analyzer directly with Python:
+
+```
+python lfn_batch_file_analyzer.py <audio_directory> [--block-duration SECONDS]
+```
+
+or use the Windows helper script `run_lfn_batch_analysis.bat` which prompts for a folder and launches the analyzer.
+
+The analyzer accepts **WAV**, **MP3**, **MP4**, and **M4A** files. Non‑WAV inputs are automatically converted before processing. Results are written to `lfn_analysis_results.csv` and spectrogram images are saved to the `spectrograms` folder within the chosen directory.
+

--- a/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LFN_Docker_Toolkit_Extended/LFN_Docker_Toolkit_Extended/lfn_batch_file_analyzer.py
+++ b/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LFN_Docker_Toolkit_Extended/LFN_Docker_Toolkit_Extended/lfn_batch_file_analyzer.py
@@ -161,7 +161,7 @@ def main():
     files = [
         f
         for f in os.listdir(input_dir)
-        if f.lower().split(".")[-1] in ["wav", "mp3", "mp4"]
+        if f.lower().split(".")[-1] in ["wav", "mp3", "mp4", "m4a"]
     ]
     for file in tqdm(files, desc="Files", unit="file"):
         ext = file.lower().split(".")[-1]

--- a/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LFN_Docker_Toolkit_Extended/LFN_Docker_Toolkit_Extended/run_lfn_batch_analysis.bat
+++ b/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/LFN_Docker_Toolkit_Extended/LFN_Docker_Toolkit_Extended/run_lfn_batch_analysis.bat
@@ -2,7 +2,7 @@
 SETLOCAL ENABLEEXTENSIONS
 
 :: Prompt for path to folder containing audio files
-set /P "AUDIO_DIR=Enter full path to folder containing audio files (mp3, mp4, wav): "
+set /P "AUDIO_DIR=Enter full path to folder containing audio files (mp3, mp4, m4a, wav): "
 
 :: Check if folder exists
 IF NOT EXIST "%AUDIO_DIR%" (

--- a/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/README.md
+++ b/Mute-Voce-2.0-main (1)/Mute-Voce-2.0-main/Mute-Voce-main/README.md
@@ -4,7 +4,9 @@ Analyze audio for soft voices—far-field or similar—enhance the signal, perfo
 ## LFN Batch File Analyzer
 
 The script `LFN_Docker_Toolkit_Extended/LFN_Docker_Toolkit_Extended/lfn_batch_file_analyzer.py`
-analyzes audio files for low‑frequency noise (LFN) and ultrasonic peaks.
+analyzes audio files for low‑frequency noise (LFN) and ultrasonic peaks. It
+accepts **WAV**, **MP3**, **MP4**, and **M4A** inputs, converting non‑WAV formats
+to WAV before processing.
 
 ```
 python lfn_batch_file_analyzer.py <directory> [--block-duration SECONDS]


### PR DESCRIPTION
## Summary
- allow the LFN batch analyzer to handle `.m4a` inputs
- document supported audio formats in the README
- update Windows batch helper to mention m4a files
- add setup and usage guide for the LFN Docker Toolkit Extended

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c9af60ba48320b3d1057cee26553c